### PR TITLE
fix: resolve all golangci-lint errors and warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,10 @@ run:
   tests: false
 
 linters-settings:
+  forbidigo:
+    forbid:
+      - .*\.Fatal.*
+      - fmt\.Print.*
   tagliatelle:
     case:
       rules:

--- a/internal/client/processor_client.go
+++ b/internal/client/processor_client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -11,24 +12,40 @@ import (
 	"github.com/stsolovey/diplom-distributed-system/internal/models"
 )
 
-// defaultHTTPClient - переиспользуемый HTTP клиент с connection pooling
-var defaultHTTPClient = &http.Client{
-	Timeout: 5 * time.Second,
-	Transport: &http.Transport{
-		MaxIdleConns:        100,
-		MaxIdleConnsPerHost: 10,
-		IdleConnTimeout:     90 * time.Second,
-		DisableCompression:  false,
-	},
-}
+const (
+	defaultTimeout      = 5 * time.Second
+	maxIdleConns        = 100
+	maxIdleConnsPerHost = 10
+	idleConnTimeout     = 90 * time.Second
+	enqueueEndpoint     = "/enqueue"
+	contentTypeHeader   = "Content-Type"
+	jsonContentType     = "application/json"
+)
 
-// ProcessorClient - клиент для отправки сообщений в Processor
+var (
+	// ErrUnexpectedStatusCode - ошибка при получении неожиданного HTTP статуса.
+	ErrUnexpectedStatusCode = errors.New("unexpected status code")
+
+	// defaultHTTPClient - переиспользуемый HTTP клиент с connection pooling.
+	//nolint:gochecknoglobals // reuse of HTTP client for connection pooling is intentional.
+	defaultHTTPClient = &http.Client{
+		Timeout: defaultTimeout,
+		Transport: &http.Transport{
+			MaxIdleConns:        maxIdleConns,
+			MaxIdleConnsPerHost: maxIdleConnsPerHost,
+			IdleConnTimeout:     idleConnTimeout,
+			DisableCompression:  false,
+		},
+	}
+)
+
+// ProcessorClient - клиент для отправки сообщений в Processor.
 type ProcessorClient struct {
 	baseURL    string
 	httpClient *http.Client
 }
 
-// NewProcessorClient создает новый клиент с переиспользуемым HTTP client
+// NewProcessorClient создает новый клиент с переиспользуемым HTTP client.
 func NewProcessorClient(baseURL string) *ProcessorClient {
 	return &ProcessorClient{
 		baseURL:    baseURL,
@@ -36,19 +53,19 @@ func NewProcessorClient(baseURL string) *ProcessorClient {
 	}
 }
 
-// SendMessage отправляет сообщение в Processor для обработки
+// SendMessage отправляет сообщение в Processor для обработки.
 func (c *ProcessorClient) SendMessage(ctx context.Context, msg *models.DataMessage) error {
 	data, err := json.Marshal(msg)
 	if err != nil {
 		return fmt.Errorf("failed to marshal message: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+"/enqueue", bytes.NewReader(data))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+enqueueEndpoint, bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
 
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(contentTypeHeader, jsonContentType)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -57,7 +74,7 @@ func (c *ProcessorClient) SendMessage(ctx context.Context, msg *models.DataMessa
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusAccepted {
-		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		return fmt.Errorf("%w: %d", ErrUnexpectedStatusCode, resp.StatusCode)
 	}
 
 	return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,11 @@ import (
 	"strconv"
 )
 
+const (
+	defaultProcessorWorkers = 4
+	defaultQueueSize        = 1000
+)
+
 type Config struct {
 	// API Gateway настройки
 	APIPort string
@@ -25,15 +30,15 @@ type Config struct {
 	NATSURL   string // URL для подключения к NATS
 }
 
-// LoadConfig загружает конфигурацию из переменных окружения
+// LoadConfig загружает конфигурацию из переменных окружения.
 func LoadConfig() *Config {
 	return &Config{
 		APIPort:          getEnv("API_PORT", "8080"),
 		IngestPort:       getEnv("INGEST_PORT", "8081"),
 		ProcessorPort:    getEnv("PROCESSOR_PORT", "8082"),
-		ProcessorWorkers: getEnvAsInt("PROCESSOR_WORKERS", 4),
+		ProcessorWorkers: getEnvAsInt("PROCESSOR_WORKERS", defaultProcessorWorkers),
 		ProcessorURL:     getEnv("PROCESSOR_URL", "http://localhost:8082"),
-		QueueSize:        getEnvAsInt("QUEUE_SIZE", 1000),
+		QueueSize:        getEnvAsInt("QUEUE_SIZE", defaultQueueSize),
 
 		QueueType: getEnv("QUEUE_TYPE", "memory"),
 		NATSURL:   getEnv("NATS_URL", "nats://localhost:4222"),
@@ -44,6 +49,7 @@ func getEnv(key, defaultValue string) string {
 	if value := os.Getenv(key); value != "" {
 		return value
 	}
+
 	return defaultValue
 }
 
@@ -52,5 +58,6 @@ func getEnvAsInt(key string, defaultValue int) int {
 	if value, err := strconv.Atoi(valueStr); err == nil {
 		return value
 	}
+
 	return defaultValue
 }

--- a/internal/queue/adapter.go
+++ b/internal/queue/adapter.go
@@ -6,32 +6,38 @@ import (
 	"github.com/stsolovey/diplom-distributed-system/internal/models"
 )
 
-// MemoryQueueAdapter адаптирует MemoryQueue для использования через интерфейсы
-// Это позволит легко заменить на NATS в Фазе 2
-type MemoryQueueAdapter struct {
+// MemoryAdapter адаптирует MemoryQueue для использования через интерфейсы.
+// Это позволит легко заменить на NATS в Фазе 2.
+type MemoryAdapter struct {
 	queue *MemoryQueue
 }
 
-// NewMemoryQueueAdapter создает новый адаптер
-func NewMemoryQueueAdapter(size int) QueueProvider {
-	return &MemoryQueueAdapter{
+const memoryAdapterBufferSize = 100
+
+// revive:disable:ireturn
+// NewMemoryAdapter создает новый адаптер.
+func NewMemoryAdapter(size int) *MemoryAdapter {
+	return &MemoryAdapter{
 		queue: NewMemoryQueue(size),
 	}
 }
 
-// Publish реализует интерфейс Publisher
-func (a *MemoryQueueAdapter) Publish(ctx context.Context, msg *models.DataMessage) error {
+// revive:enable:ireturn
+
+// Publish реализует интерфейс Publisher.
+func (a *MemoryAdapter) Publish(ctx context.Context, msg *models.DataMessage) error {
 	return a.queue.Publish(ctx, msg)
 }
 
-// Subscribe реализует интерфейс Subscriber
-// Для MemoryQueue используем простой подход через канал
-func (a *MemoryQueueAdapter) Subscribe(ctx context.Context) (<-chan *models.DataMessage, error) {
-	msgChan := make(chan *models.DataMessage, 100)
+// Subscribe реализует интерфейс Subscriber.
+// Для MemoryQueue используем простой подход через канал.
+func (a *MemoryAdapter) Subscribe(ctx context.Context) (<-chan *models.DataMessage, error) {
+	msgChan := make(chan *models.DataMessage, memoryAdapterBufferSize)
 
-	// Запускаем горутину для чтения из очереди
+	// Запускаем горутину для чтения из очереди.
 	go func() {
 		defer close(msgChan)
+
 		for {
 			msg, err := a.queue.Dequeue(ctx)
 			if err != nil {
@@ -49,18 +55,18 @@ func (a *MemoryQueueAdapter) Subscribe(ctx context.Context) (<-chan *models.Data
 	return msgChan, nil
 }
 
-// Stats возвращает статистику
-func (a *MemoryQueueAdapter) Stats() QueueStats {
+// Stats возвращает статистику.
+func (a *MemoryAdapter) Stats() Stats {
 	return a.queue.Stats()
 }
 
-// Close закрывает адаптер
-func (a *MemoryQueueAdapter) Close() error {
+// Close закрывает адаптер.
+func (a *MemoryAdapter) Close() error {
 	return a.queue.Close()
 }
 
-// GetUnderlyingQueue возвращает базовую очередь для совместимости с существующим кодом
-// В Фазе 2 этот метод будет удален
-func (a *MemoryQueueAdapter) GetUnderlyingQueue() *MemoryQueue {
+// GetUnderlyingQueue возвращает базовую очередь для совместимости с существующим кодом.
+// В Фазе 2 этот метод будет удален.
+func (a *MemoryAdapter) GetUnderlyingQueue() *MemoryQueue {
 	return a.queue
 }

--- a/internal/queue/interface.go
+++ b/internal/queue/interface.go
@@ -6,25 +6,25 @@ import (
 	"github.com/stsolovey/diplom-distributed-system/internal/models"
 )
 
-// Publisher интерфейс для публикации сообщений
+// Publisher интерфейс для публикации сообщений.
 type Publisher interface {
 	Publish(ctx context.Context, msg *models.DataMessage) error
 }
 
-// Subscriber интерфейс для подписки на сообщения
+// Subscriber интерфейс для подписки на сообщения.
 type Subscriber interface {
 	Subscribe(ctx context.Context) (<-chan *models.DataMessage, error)
 	Close() error
 }
 
-// QueueProvider объединяет Publisher и Subscriber
-type QueueProvider interface {
+// Provider объединяет Publisher и Subscriber.
+type Provider interface {
 	Publisher
 	Subscriber
-	Stats() QueueStats
+	Stats() Stats
 }
 
-// MessageBroker интерфейс для брокеров сообщений (для будущей интеграции с NATS/Kafka)
+// MessageBroker интерфейс для брокеров сообщений (для будущей интеграции с NATS/Kafka).
 type MessageBroker interface {
 	Connect(ctx context.Context) error
 	Disconnect() error

--- a/internal/queue/memory_queue.go
+++ b/internal/queue/memory_queue.go
@@ -3,6 +3,7 @@ package queue
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 
 	"github.com/stsolovey/diplom-distributed-system/internal/models"
@@ -13,37 +14,41 @@ var (
 	ErrQueueClosed = errors.New("queue is closed")
 )
 
-// MemoryQueue - потокобезопасная in-memory очередь
+// MemoryQueue - потокобезопасная in-memory очередь.
 type MemoryQueue struct {
 	messages chan *models.DataMessage
 	mu       sync.RWMutex
 	closed   bool
-	stats    QueueStats
+	stats    Stats
 }
 
-type QueueStats struct {
+const memoryQueueBufferSize = 100
+
+// Stats содержит статистику очереди.
+type Stats struct {
 	TotalEnqueued int64
 	TotalDequeued int64
 	CurrentSize   int
 }
 
-// NewMemoryQueue создает новую очередь заданного размера
+// NewMemoryQueue создает новую очередь заданного размера.
 func NewMemoryQueue(size int) *MemoryQueue {
 	return &MemoryQueue{
 		messages: make(chan *models.DataMessage, size),
 	}
 }
 
-// Publish реализует интерфейс Publisher (алиас для Enqueue)
+// Publish реализует интерфейс Publisher (алиас для Enqueue).
 func (q *MemoryQueue) Publish(ctx context.Context, msg *models.DataMessage) error {
 	return q.Enqueue(ctx, msg)
 }
 
-// Enqueue добавляет сообщение в очередь (неблокирующий)
+// Enqueue добавляет сообщение в очередь (неблокирующий).
 func (q *MemoryQueue) Enqueue(ctx context.Context, msg *models.DataMessage) error {
 	q.mu.RLock()
 	if q.closed {
 		q.mu.RUnlock()
+
 		return ErrQueueClosed
 	}
 	q.mu.RUnlock()
@@ -53,43 +58,48 @@ func (q *MemoryQueue) Enqueue(ctx context.Context, msg *models.DataMessage) erro
 		q.mu.Lock()
 		q.stats.TotalEnqueued++
 		q.mu.Unlock()
+
 		return nil
 	case <-ctx.Done():
-		return ctx.Err()
+		return fmt.Errorf("enqueue canceled: %w", ctx.Err())
 	default:
 		return ErrQueueFull
 	}
 }
 
-// Dequeue извлекает сообщение из очереди (блокирующий)
+// Dequeue извлекает сообщение из очереди (блокирующий).
 func (q *MemoryQueue) Dequeue(ctx context.Context) (*models.DataMessage, error) {
 	select {
 	case msg := <-q.messages:
 		if msg == nil {
 			return nil, ErrQueueClosed
 		}
+
 		q.mu.Lock()
 		q.stats.TotalDequeued++
 		q.mu.Unlock()
+
 		return msg, nil
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return nil, fmt.Errorf("dequeue canceled: %w", ctx.Err())
 	}
 }
 
-// Subscribe реализует интерфейс Subscriber для совместимости с WorkerPool
+// Subscribe реализует интерфейс Subscriber для совместимости с WorkerPool.
 func (q *MemoryQueue) Subscribe(ctx context.Context) (<-chan *models.DataMessage, error) {
-	msgChan := make(chan *models.DataMessage, 100)
+	msgChan := make(chan *models.DataMessage, memoryQueueBufferSize)
 
 	go func() {
 		defer close(msgChan)
+
 		for {
 			msg, err := q.Dequeue(ctx)
 			if err != nil {
-				if err == context.Canceled || err == ErrQueueClosed {
+				if errors.Is(err, context.Canceled) || errors.Is(err, ErrQueueClosed) {
 					return
 				}
-				// При других ошибках продолжаем попытки
+
+				// При других ошибках продолжаем попытки.
 				continue
 			}
 
@@ -104,22 +114,25 @@ func (q *MemoryQueue) Subscribe(ctx context.Context) (<-chan *models.DataMessage
 	return msgChan, nil
 }
 
-// Stats возвращает статистику очереди
-func (q *MemoryQueue) Stats() QueueStats {
+// Stats возвращает статистику очереди.
+func (q *MemoryQueue) Stats() Stats {
 	q.mu.RLock()
 	defer q.mu.RUnlock()
 	stats := q.stats
 	stats.CurrentSize = len(q.messages)
+
 	return stats
 }
 
-// Close закрывает очередь
+// Close закрывает очередь.
 func (q *MemoryQueue) Close() error {
 	q.mu.Lock()
 	defer q.mu.Unlock()
+
 	if !q.closed {
 		q.closed = true
 		close(q.messages)
 	}
+
 	return nil
 }

--- a/internal/queue/nats_publisher.go
+++ b/internal/queue/nats_publisher.go
@@ -3,6 +3,7 @@ package queue
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/nats-io/nats.go/jetstream"
@@ -14,7 +15,9 @@ type NATSPublisher struct {
 	subject string
 }
 
-// NewNATSPublisher создает publisher для конкретного subject
+var ErrNATSPublisherAck = errors.New("received nil acknowledgment from JetStream")
+
+// NewNATSPublisher создает publisher для конкретного subject.
 func NewNATSPublisher(broker *NATSBroker, subject string) *NATSPublisher {
 	return &NATSPublisher{
 		js:      broker.js,
@@ -22,7 +25,7 @@ func NewNATSPublisher(broker *NATSBroker, subject string) *NATSPublisher {
 	}
 }
 
-// Publish отправляет сообщение в NATS JetStream с гарантией доставки
+// Publish отправляет сообщение в NATS JetStream с гарантией доставки.
 func (p *NATSPublisher) Publish(ctx context.Context, msg *models.DataMessage) error {
 	data, err := json.Marshal(msg)
 	if err != nil {
@@ -37,7 +40,7 @@ func (p *NATSPublisher) Publish(ctx context.Context, msg *models.DataMessage) er
 
 	// Проверяем, что сообщение было успешно сохранено в JetStream
 	if ack == nil {
-		return fmt.Errorf("received nil acknowledgment from JetStream")
+		return fmt.Errorf("%w", ErrNATSPublisherAck)
 	}
 
 	// В современной версии NATS JetStream ACK возвращается синхронно


### PR DESCRIPTION
- Remove magic numbers by extracting constants

- Fix error handling patterns (err113, goerr113)

- Remove global variables using App struct pattern

- Add missing comment periods (godot)

- Fix whitespace and spacing issues (wsl, nlreturn)

- Use proper JSON tags format (tagliatelle)

- Replace proto field access with getters (protogetter)

- Fix type stuttering in queue package

- Improve error comparisons with errors.Is

- Add timeout constants for HTTP operations

- Fix exitAfterDefer issues with proper error handling

- Add nolint directives for justified suppressions

- Update forbidigo config to disallow log.Fatal and fmt.Print

- Replace log.Fatalf with log.Printf + os.Exit(1)

All tests pass, build succeeds, linter reports zero issues.

Code quality significantly improved while maintaining functionality.